### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,9 @@ php:
   - 7.1
   - 7.2
   - nightly
+env:
+  - COMPOSER_REQUIRE="echo"
+  - COMPOSER_REQUIRE="composer require masterminds/html5"
+install:
+  - $COMPOSER_REQUIRE
 before_script: composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - 7.2
   - nightly
 env:
-  - COMPOSER_REQUIRE="echo"
+  - COMPOSER_REQUIRE=""
   - COMPOSER_REQUIRE="composer require masterminds/html5"
 install:
   - $COMPOSER_REQUIRE


### PR DESCRIPTION
runs two sets of builds, with and without the html5 parser